### PR TITLE
Remove the EveryoneShouldHaveAVoice.com permission.

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -536,13 +536,5 @@ chrome.storage.local.get(['options'],function(storage) {
     addEventListener('DOMContentLoaded',welcome);
   }
 
-  // Fetch an updated config from the server
-  // fetch('https://EveryoneShouldHaveAVoice.com/config.json').json().then((json)=>{
-  //   let k;
-  //   for (k in json) {
-  //     config[k] = json[k];
-  //   }
-  // });
-
   setInterval(attach,1000);
 });

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,7 +4,7 @@
   "manifest_version": 2,
   "name": "Talk Time for Google Meet",
   "author": "Matt Kruse",
-  "version": "3.1",
+  "version": "3.2",
   "homepage_url": "https://EveryoneShouldHaveAVoice.com/",
   "icons": {
     "16": "icon-16.png",
@@ -14,8 +14,7 @@
   },
   "permissions": [
     "storage",
-    "https://meet.google.com/*",
-    "https://EveryoneShouldHaveAVoice.com/*"
+    "https://meet.google.com/*"
   ],
   "content_scripts": [
     {


### PR DESCRIPTION
The `https://EveryoneShouldHaveAVoice.com/*` permission does not appear to be used anywhere, except some commented code that I also removed.

I bumped the minor version number in the manifest.